### PR TITLE
Fix search placeholder text localisation

### DIFF
--- a/web/site/cart.html
+++ b/web/site/cart.html
@@ -16,7 +16,7 @@
         stores
         misc
         nochartclear
-        placeholder="__Produkt hinzufügen...__ (__min. 3 Zeichen__)"
+        placeholder="__Produkt hinzufügen...__ __(min. 3 Zeichen)__"
     ></items-filter>
     <items-list x-id="productsList" class="hidden" add></items-list>
     %%_templates/_loader.html%%


### PR DESCRIPTION
This fixes the "(at least 3 characters)" placeholder text in the search box, which is currently not localised/translated.

This is a replication of my upstream pull request - https://github.com/badlogic/heissepreise/pull/163