### PR TITLE
woolies: exclude Everyday Market products + restore dropped products

### DIFF
--- a/hotprices_au/sites/woolies.py
+++ b/hotprices_au/sites/woolies.py
@@ -40,16 +40,8 @@ class WooliesAPI:
                 "isSpecial": false,
                 "isBundle": false,
                 "isMobile": false,
-                "filters": [
-                    {
-                        "Items": [
-                            {
-                                "Term": "Woolworths"
-                            }
-                        ],
-                        "Key": "SoldBy"
-                    }
-                ],
+                "isHideEverydayMarketProducts": true,
+                "filters": [],
                 "token": "",
                 "gpBoost": 0,
                 "isHideUnavailableProducts": false,
@@ -77,6 +69,17 @@ class WooliesAPI:
             response.raise_for_status()
             response_data = response.json()
             for bundle in response_data["Bundles"]:
+                # isHideEverydayMarketProducts should exclude marketplace
+                # products server-side; this is a safety net in case the API
+                # stops honouring it (like it did with the SoldBy filter).
+                products = [
+                    product
+                    for product in bundle["Products"]
+                    if not product.get("IsMarketProduct")
+                ]
+                if not products:
+                    continue
+                bundle["Products"] = products
                 yield bundle
 
             # Next page calculation


### PR DESCRIPTION
Problem: The Woolies category API silently ignores the SoldBy=Woolworths filter, so every category was flooded with bs Everyday Market listings (e.g. Cleaning & Maintenance returns 66k products, only ~2k of them sold by Woolies). Since the API also stops returning products past 10,000 per category, any supermarket product sorting past that cutoff was never scraped - e.g. paper towels (Handee, Viva, Quilton) were missing entirely.

Fix: Send isHideEverydayMarketProducts=true in the API request so the API filters marketplace products, which keeps every category well under the 10k cap. Also drop marketplace products client-side as a safety net in case this filter ever breaks like SoldBy did.

Verified with two full scrapes: 23,640 unique products, all with prices, zero marketplace items; previously-missing products now present. Note: hotprices_au/data/woolies-categories.json is quite stale (many renamed/new subcategories, ~10.8k products currently uncategorised), left out of this PR to keep the diff reviewable